### PR TITLE
Added tests which use an UInt32 instead of a struct with 4 UInt8.

### DIFF
--- a/src/main.swift
+++ b/src/main.swift
@@ -24,7 +24,10 @@ let header = "Language: Swift, Optimization: -\(opt), Samples = \(NumberOfSample
 perflib.header(header)
 
 perflib.test("RenderGradient ([Pixel])", NumberOfSamples, NumberOfIterations, renderGradient_PixelArray)
+perflib.test("RenderGradient ([UInt32])", NumberOfSamples, NumberOfIterations, renderGradient_PixelArray_UInt32)
 perflib.test("RenderGradient (UnsafeMutablePointer)", NumberOfSamples, NumberOfIterations, renderGradient_unsafeMutablePointer)
+perflib.test("RenderGradient (UnsafeMutablePointer<UInt32>)", NumberOfSamples, NumberOfIterations, renderGradient_unsafeMutablePointer_UInt32)
 perflib.test("RenderGradient ([Pixel].withUnsafeMutablePointer)", NumberOfSamples, NumberOfIterations, renderGradient_ArrayUsingUnsafeMutablePointer)
+perflib.test("RenderGradient ([UInt32].withUnsafeMutablePointer)", NumberOfSamples, NumberOfIterations, renderGradient_ArrayUsingUnsafeMutablePointer_UInt32)
 
 perflib.separator()

--- a/src/tests/RenderGradient.swift
+++ b/src/tests/RenderGradient.swift
@@ -56,6 +56,59 @@ func renderGradient_PixelArray(samples: Int, iterations: Int) -> Result {
     }
 }
 
+func renderGradient_PixelArray_UInt32(samples: Int, iterations: Int) -> Result {
+    typealias Pixel = UInt32
+    
+    func rgba(red: UInt8, green: UInt8, blue: UInt8, alpha: UInt8) -> Pixel {
+        let r = UInt32(red)
+        let g = UInt32(green) << 8
+        let b = UInt32(blue) << 16
+        let a = UInt32(alpha) << 24
+        return r | g | b | a
+    }
+    
+    struct RenderBuffer {
+        var pixels: [Pixel]
+        var width: Int
+        var height: Int
+        
+        init(width: Int, height: Int) {
+            assert(width > 0)
+            assert(height > 0)
+            
+            let pixel = rgba(0, 0, 0, 0xFF)
+            pixels = [Pixel](count: width * height, repeatedValue: pixel)
+            
+            self.width = width
+            self.height = height
+        }
+    }
+    
+    func RenderGradient(inout buffer: RenderBuffer, offsetX: Int, offsetY: Int)
+    {
+        // I truly hope you have turned down the number of iterations or you have picked
+        // up a new build of Swift where this is not dog slow with -Onone.
+        var offset = 0
+        for (var y = 0, height = buffer.height; y < height; ++y) {
+            for (var x = 0, width = buffer.width; x < width; ++x) {
+                let pixel = rgba(
+                    0,
+                    UInt8((y + offsetY) & 0xFF),
+                    UInt8((x + offsetX) & 0xFF),
+                    0xFF)
+                buffer.pixels[offset] = pixel;
+                ++offset;
+            }
+        }
+    }
+    
+    var buffer = RenderBuffer(width: 960, height: 540)
+    
+    return perflib.measure(samples, iterations) {
+        RenderGradient(&buffer, 2, 1)
+    }
+}
+
 func renderGradient_unsafeMutablePointer(samples: Int, iterations: Int) -> Result {
     struct Pixel {
         var red: UInt8
@@ -109,6 +162,62 @@ func renderGradient_unsafeMutablePointer(samples: Int, iterations: Int) -> Resul
     }
 }
 
+func renderGradient_unsafeMutablePointer_UInt32(samples: Int, iterations: Int) -> Result {
+    typealias Pixel = UInt32
+    
+    func rgba(red: UInt8, green: UInt8, blue: UInt8, alpha: UInt8) -> Pixel {
+        let r = UInt32(red)
+        let g = UInt32(green) << 8
+        let b = UInt32(blue) << 16
+        let a = UInt32(alpha) << 24
+        return r | g | b | a
+    }
+    
+    struct RenderBuffer {
+        var pixels: UnsafeMutablePointer<Pixel>
+        var width: Int
+        var height: Int
+        
+        init(width: Int, height: Int) {
+            assert(width > 0)
+            assert(height > 0)
+            
+            pixels = UnsafeMutablePointer.alloc(width * height * sizeof(Pixel))
+            
+            self.width = width
+            self.height = height
+        }
+        
+        mutating func release() {
+            pixels.dealloc(width * height * sizeof(Pixel))
+            width = 0
+            height = 0
+        }
+    }
+    
+    func RenderGradient(inout buffer: RenderBuffer, offsetX: Int, offsetY: Int)
+    {
+        var offset = 0
+        for (var y = 0, height = buffer.height; y < height; ++y) {
+            for (var x = 0, width = buffer.width; x < width; ++x) {
+                let pixel = rgba(
+                    0,
+                    UInt8((y + offsetY) & 0xFF),
+                    UInt8((x + offsetX) & 0xFF),
+                    0xFF)
+                buffer.pixels[offset] = pixel;
+                ++offset;
+            }
+        }
+    }
+    
+    var buffer = RenderBuffer(width: 960, height: 540)
+    
+    return perflib.measure(samples, iterations) {
+        RenderGradient(&buffer, 2, 1)
+    }
+}
+
 func renderGradient_ArrayUsingUnsafeMutablePointer(samples: Int, iterations: Int) -> Result {
     struct Pixel {
         var red: UInt8
@@ -147,6 +256,61 @@ func renderGradient_ArrayUsingUnsafeMutablePointer(samples: Int, iterations: Int
                         green: UInt8((y + offsetY) & 0xFF),
                         blue: UInt8((x + offsetX) & 0xFF),
                         alpha: 0xFF)
+                    p[offset] = pixel
+                    ++offset;
+                }
+            }
+        }
+    }
+    
+    var buffer = RenderBuffer(width: 960, height: 540)
+    
+    return perflib.measure(samples, iterations) {
+        RenderGradient(&buffer, 2, 1)
+    }
+}
+
+func renderGradient_ArrayUsingUnsafeMutablePointer_UInt32(samples: Int, iterations: Int) -> Result {
+    typealias Pixel = UInt32
+    
+    func rgba(red: UInt8, green: UInt8, blue: UInt8, alpha: UInt8) -> Pixel {
+        let r = UInt32(red)
+        let g = UInt32(green) << 8
+        let b = UInt32(blue) << 16
+        let a = UInt32(alpha) << 24
+        return r | g | b | a
+    }
+    
+    struct RenderBuffer {
+        var pixels: [Pixel]
+        var width: Int
+        var height: Int
+        
+        init(width: Int, height: Int) {
+            assert(width > 0)
+            assert(height > 0)
+            
+            let pixel = rgba(0, 0, 0, 0xFF)
+            pixels = [Pixel](count: width * height, repeatedValue: pixel)
+            
+            self.width = width
+            self.height = height
+        }
+    }
+    
+    func RenderGradient(inout buffer: RenderBuffer, offsetX: Int, offsetY: Int)
+    {
+        // Turn this code on for at least some sanity back to your debug builds. It's still
+        // going to be slow, but at compared to the code above, it's going to feel glorious.
+        buffer.pixels.withUnsafeMutableBufferPointer { (inout p: UnsafeMutableBufferPointer<Pixel>) -> () in
+            var offset = 0
+            for (var y = 0, height = buffer.height; y < height; ++y) {
+                for (var x = 0, width = buffer.width; x < width; ++x) {
+                    let pixel = rgba(
+                        0,
+                        UInt8((y + offsetY) & 0xFF),
+                        UInt8((x + offsetX) & 0xFF),
+                        0xFF)
                     p[offset] = pixel
                     ++offset;
                 }


### PR DESCRIPTION
Hi David,

Thanks for putting these tests together. I found them only after writing my own gradient rendering code when attempting to figure out whether my solution was any good. I went the `UnsafeMutablePointer` route, but used an `UInt32` instead of a struct with 4 `UInt8`s. So I added a `UInt32` version for each of your variants. The code is almost identical to yours.

For -Onone, using an `UInt32` is actually slower, so unfortunately it doesn't help there. But for -O, it's already significantly faster (15 - 25%). And for -Ounchecked, it's 2 - 3.5 times as fast.

In the -Ounchecked case, I find it interesting that the `[UInt32]` version is significantly faster than the `UnsafeMutablePointer<UInt32>` version. Though the `[UInt32].withUnsafeMutablePointer` version beats them both.

The `[UInt32].withUnsafeMutablePointer` is what I'll be going with in my code. For my use case, it's plenty fast enough.

Cheers,
Greg


Here are some numbers from my iMac (5K, late 2014)(4 GHz i7, 24 GB RAM) running Swift 1.2 with Xcode 6.3.1 (6D1002):

    $ make
    > Building ANSI C -O0
    > Building ANSI C -Os
    > Building ANSI C -Ofast
    > Building Swift -Onone
    > Building Swift -O
    > Building Swift -Ounchecked

    Language: C, Optimization: -O0, Samples = 10, Iterations = 30             ┃ Avg (ms) ┃ Min (ms) ┃ Max (ms) ┃ StdDev ┃
    ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━╇━━━━━━━━━━╇━━━━━━━━━━╇━━━━━━━━━━╇━━━━━━━━┩
    RenderGradient (Pointer Math)                                             │   29.601 │   29.209 │   30.753 │  0.502 │
    ──────────────────────────────────────────────────────────────────────────┴──────────┴──────────┴──────────┴────────┘

    Language: C, Optimization: -Os, Samples = 10, Iterations = 30             ┃ Avg (ms) ┃ Min (ms) ┃ Max (ms) ┃ StdDev ┃
    ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━╇━━━━━━━━━━╇━━━━━━━━━━╇━━━━━━━━━━╇━━━━━━━━┩
    RenderGradient (Pointer Math)                                             │    7.442 │    7.189 │    7.876 │  0.243 │
    ──────────────────────────────────────────────────────────────────────────┴──────────┴──────────┴──────────┴────────┘

    Language: C, Optimization: -Ofast, Samples = 10, Iterations = 30          ┃ Avg (ms) ┃ Min (ms) ┃ Max (ms) ┃ StdDev ┃
    ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━╇━━━━━━━━━━╇━━━━━━━━━━╇━━━━━━━━━━╇━━━━━━━━┩
    RenderGradient (Pointer Math)                                             │    2.080 │    1.990 │    2.594 │  0.196 │
    ──────────────────────────────────────────────────────────────────────────┴──────────┴──────────┴──────────┴────────┘

    Language: Swift, Optimization: -Onone, Samples = 10, Iterations = 30      ┃ Avg (ms) ┃ Min (ms) ┃ Max (ms) ┃ StdDev ┃
    ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━╇━━━━━━━━━━╇━━━━━━━━━━╇━━━━━━━━━━╇━━━━━━━━┩
    RenderGradient ([Pixel])                                                  │ 2637.851 │ 2627.736 │ 2661.067 │ 9.8016 │
    RenderGradient ([UInt32])                                                 │ 2641.931 │ 2635.797 │ 2648.014 │ 4.7161 │
    RenderGradient (UnsafeMutablePointer)                                     │ 126.5387 │ 126.2294 │ 127.9877 │ 0.5296 │
    RenderGradient (UnsafeMutablePointer<UInt32>)                             │ 147.9134 │ 146.6090 │ 155.9518 │ 2.8578 │
    RenderGradient ([Pixel].withUnsafeMutablePointer)                         │ 275.3100 │ 274.7384 │ 276.2678 │ 0.5180 │
    RenderGradient ([UInt32].withUnsafeMutablePointer)                        │ 284.0742 │ 282.7588 │ 289.6570 │ 2.1847 │
    ──────────────────────────────────────────────────────────────────────────┴──────────┴──────────┴──────────┴────────┘

    Language: Swift, Optimization: -O, Samples = 10, Iterations = 30          ┃ Avg (ms) ┃ Min (ms) ┃ Max (ms) ┃ StdDev ┃
    ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━╇━━━━━━━━━━╇━━━━━━━━━━╇━━━━━━━━━━╇━━━━━━━━┩
    RenderGradient ([Pixel])                                                  │ 16.36818 │ 16.12194 │ 16.94038 │ 0.2636 │
    RenderGradient ([UInt32])                                                 │ 14.37695 │ 14.28190 │ 14.67553 │ 0.1227 │
    RenderGradient (UnsafeMutablePointer)                                     │ 16.12808 │ 15.74682 │ 18.23523 │ 0.7580 │
    RenderGradient (UnsafeMutablePointer<UInt32>)                             │ 12.03086 │ 11.85297 │ 12.44841 │  0.181 │
    RenderGradient ([Pixel].withUnsafeMutablePointer)                         │ 15.88839 │ 15.72620 │ 16.44694 │ 0.2498 │
    RenderGradient ([UInt32].withUnsafeMutablePointer)                        │ 11.95530 │ 11.85689 │ 12.15047 │ 0.0967 │
    ──────────────────────────────────────────────────────────────────────────┴──────────┴──────────┴──────────┴────────┘

    Language: Swift, Optimization: -Ounchecked, Samples = 10, Iterations = 30 ┃ Avg (ms) ┃ Min (ms) ┃ Max (ms) ┃ StdDev ┃
    ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━╇━━━━━━━━━━╇━━━━━━━━━━╇━━━━━━━━━━╇━━━━━━━━┩
    RenderGradient ([Pixel])                                                  │ 16.13090 │ 15.93064 │ 16.44715 │ 0.2055 │
    RenderGradient ([UInt32])                                                 │ 5.504373 │  5.43783 │ 5.657989 │  0.084 │
    RenderGradient (UnsafeMutablePointer)                                     │ 16.23333 │ 15.88524 │ 16.85124 │ 0.4086 │
    RenderGradient (UnsafeMutablePointer<UInt32>)                             │ 7.491316 │ 7.265724 │ 7.948163 │ 0.2611 │
    RenderGradient ([Pixel].withUnsafeMutablePointer)                         │ 16.01333 │ 15.91475 │ 16.38391 │ 0.1523 │
    RenderGradient ([UInt32].withUnsafeMutablePointer)                        │ 4.693582 │ 4.650093 │ 4.935639 │ 0.0918 │
    ──────────────────────────────────────────────────────────────────────────┴──────────┴──────────┴──────────┴────────┘
